### PR TITLE
Kyua framework does not build up with /usr/obj

### DIFF
--- a/external/bsd/kyua-testers/libexec/kyua-atf-tester/Makefile
+++ b/external/bsd/kyua-testers/libexec/kyua-atf-tester/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.1 2013/02/19 06:04:43 jmmv Exp $
+# $NetBSD: Makefile,v 1.2 2016/08/07 20:23:09 dholland Exp $
 
 .include <bsd.own.mk>
 
@@ -11,11 +11,12 @@ SRCS=		atf_main.c
 MAN=		kyua-atf-tester.1
 MAN+=		kyua-atf-interface.7
 
-PRIVATELIBDIR!=	cd ${.CURDIR}/../../lib; ${PRINTOBJDIR}
-LDADD+=		${PRIVATELIBDIR}/libatf_tester/libatf_tester.a
-DPADD+=		${PRIVATELIBDIR}/libatf_tester/libatf_tester.a
-LDADD+=		${PRIVATELIBDIR}/libtester/libtester.a
-DPADD+=		${PRIVATELIBDIR}/libtester/libtester.a
+ATFTESTER_LIBDIR!=	cd ${.CURDIR}/../../lib/libatf_tester; ${PRINTOBJDIR}
+TESTER_LIBDIR!=		cd ${.CURDIR}/../../lib/libtester; ${PRINTOBJDIR}
+LDADD+=		${ATFTESTER_LIBDIR}/libatf_tester.a
+DPADD+=		${ATFTESTER_LIBDIR}/libatf_tester.a
+LDADD+=		${TESTER_LIBDIR}/libtester.a
+DPADD+=		${TESTER_LIBDIR}/libtester.a
 
 CPPFLAGS+=	-DHAVE_CONFIG_H
 CPPFLAGS+=	-I${.CURDIR}/../../lib/libtester

--- a/external/bsd/kyua-testers/libexec/kyua-plain-tester/Makefile
+++ b/external/bsd/kyua-testers/libexec/kyua-plain-tester/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.1 2013/02/19 06:04:43 jmmv Exp $
+# $NetBSD: Makefile,v 1.2 2016/08/07 20:23:09 dholland Exp $
 
 .include <bsd.own.mk>
 
@@ -11,9 +11,9 @@ SRCS=		plain_main.c
 MAN=		kyua-plain-tester.1
 MAN+=		kyua-plain-interface.7
 
-PRIVATELIBDIR!=	cd ${.CURDIR}/../../lib; ${PRINTOBJDIR}
-LDADD+=		${PRIVATELIBDIR}/libtester/libtester.a
-DPADD+=		${PRIVATELIBDIR}/libtester/libtester.a
+TESTER_LIBDIR!=		cd ${.CURDIR}/../../lib/libtester; ${PRINTOBJDIR}
+LDADD+=		${TESTER_LIBDIR}/libtester.a
+DPADD+=		${TESTER_LIBDIR}/libtester.a
 
 CPPFLAGS+=	-DHAVE_CONFIG_H
 CPPFLAGS+=	-I${.CURDIR}/../../lib/libtester

--- a/external/bsd/kyua-testers/tests/kyua-testers/Makefile
+++ b/external/bsd/kyua-testers/tests/kyua-testers/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.1 2013/02/19 06:04:44 jmmv Exp $
+# $NetBSD: Makefile,v 1.2 2016/08/07 20:23:09 dholland Exp $
 
 .include <bsd.own.mk>
 
@@ -12,11 +12,12 @@ CPPFLAGS+=	-DTESTERSDIR=\"/usr/libexec\"
 CPPFLAGS+=	-I${.CURDIR}/../../lib/libtester
 CPPFLAGS+=	-I${SRCDIR}
 
-PRIVATELIBDIR!=	cd ${.CURDIR}/../../lib; ${PRINTOBJDIR}
-.for lib in atf_tester tester
-LDADD+=		${PRIVATELIBDIR}/lib${lib}/lib${lib}.a
-DPADD+=		${PRIVATELIBDIR}/lib${lib}/lib${lib}.a
-.endfor
+ATFTESTER_LIBDIR!=	cd ${.CURDIR}/../../lib/libatf_tester; ${PRINTOBJDIR}
+TESTER_LIBDIR!=		cd ${.CURDIR}/../../lib/libtester; ${PRINTOBJDIR}
+LDADD+=		${ATFTESTER_LIBDIR}/libatf_tester.a
+DPADD+=		${ATFTESTER_LIBDIR}/libatf_tester.a
+LDADD+=		${TESTER_LIBDIR}/libtester.a
+DPADD+=		${TESTER_LIBDIR}/libtester.a
 
 TESTS_C=	atf_list_test
 TESTS_C+=	atf_result_test


### PR DESCRIPTION
#5

Reported to NetBSD as PR/51389, fix by dholland
http://gnats.netbsd.org/51389

Change-Id: I5eba9ed0803a7e2e84a0127859609e423f141308
